### PR TITLE
Adding support for settings slices as maps, and referring to their keys.

### DIFF
--- a/stylesheets/breakpoint-slicer/_helper-functions.sass
+++ b/stylesheets/breakpoint-slicer/_helper-functions.sass
@@ -27,7 +27,23 @@
 @function total-slices()
   @return length($slicer-breakpoints)
 
-  
+
+// slice-index($key)
+// - $key : <slice key> A map key of a slice.
+//
+// Returns the slice index of the given map key.
+// If $key is numeric, it is already a index, so just return it
+@function slice-index($key)
+  @if type-of($key) == number
+    @return $key
+  @else if $slicer-breakpoints-map
+    $keys: map-keys($slicer-breakpoints-map)
+    @if map-has-key($slicer-breakpoints-map, $key) == false
+      @warn "Invalid slice key provided: #{$key}. Should be one of: #{$keys}."
+    @else
+      @return index($keys, $key) - 1
+
+
 // left-bp-of-slice($slice)
 // - $slice : <slice number> A number of a slice. Should be positive integer.
 //
@@ -39,7 +55,7 @@
   // Making sure that the slice provided is valid
   @if ($slice < $min) or ($slice > $max)
 
-    @warn "Wrong Slice number provided: #{$slice}. Should be between #{min} and #{$max}."
+    @warn "Wrong slice number provided: #{$slice}. Should be between #{$min} and #{$max}."
 
   @else
 

--- a/stylesheets/breakpoint-slicer/_mixins.sass
+++ b/stylesheets/breakpoint-slicer/_mixins.sass
@@ -13,6 +13,10 @@
 // - $no-query    : [<.class>]     A class to provide the no-query fallback (see Breakpoint docs).
 =between($slice-left, $slice-right, $no-query: false)
 
+  // Get slices from map keys
+  $slice-left: slice-index($slice-left)
+  $slice-right: slice-index($slice-right)
+
   // If the slices provided are the first and the last one,
   // the breakpoint becomes meaningless
   @if ($slice-left == 1) and ($slice-right == total-slices())

--- a/stylesheets/breakpoint-slicer/_variables.sass
+++ b/stylesheets/breakpoint-slicer/_variables.sass
@@ -1,3 +1,13 @@
 // The defaults
 $slicer-breakpoints: 0 400px 600px 800px 1010px !default
+$slicer-breakpoints-map: false
+// $slicer-breakpoints-map: (sm: 400px, md: 600px, lg: 800px, xlg: 1010px) !default
 $slicer-anti-overlap-corrections: 1px !default
+
+// If we're dealing with a map:
+// - Prepend a 0 starting slice if it doesn't exist
+// - Set $slicer-breakpoints for existing logic
+@if $slicer-breakpoints-map
+  @if nth(map-values($slicer-breakpoints-map), 1) != 0
+    $slicer-breakpoints-map: map-merge((start: 0), $slicer-breakpoints-map) !global
+  $slicer-breakpoints: map-values($slicer-breakpoints-map) !global


### PR DESCRIPTION
I found Breakpoint Slicer to be [exactly what I was looking for](https://github.com/Team-Sass/breakpoint/issues/103), except I wanted to be able to refer to my named breakpoints (e.g. sm, md, lg) instead of remembering the numbers of the slices.

I added support for setting a `$slicer-breakpoints-map` instead of just a `$slicer-breakpoints` list.

Thanks for your work!
